### PR TITLE
change exists? -> exist?

### DIFF
--- a/lib/rbpad/pad.rb
+++ b/lib/rbpad/pad.rb
@@ -376,9 +376,9 @@ module Rbpad
         dialog.current_folder = @last_dir
       else
         # desktop
-        if ENV.has_key?("HOME") and Dir.exists?(ENV["HOME"] + "/Desktop")
+        if ENV.has_key?("HOME") and Dir.exist?(ENV["HOME"] + "/Desktop")
           dialog.current_folder = ENV["HOME"] + "/Desktop"
-        elsif ENV.has_key?("USERPROFILE") and Dir.exists?(ENV["USERPROFILE"] + "/Desktop")
+        elsif ENV.has_key?("USERPROFILE") and Dir.exist?(ENV["USERPROFILE"] + "/Desktop")
           dialog.current_folder = ENV["USERPROFILE"] + "/Desktop"
         end
       end
@@ -461,9 +461,9 @@ module Rbpad
         dialog.current_folder = @last_dir
       else
         # desktop
-        if ENV.has_key?("HOME") and Dir.exists?(ENV["HOME"] + "/Desktop")
+        if ENV.has_key?("HOME") and Dir.exist?(ENV["HOME"] + "/Desktop")
           dialog.current_folder = ENV["HOME"] + "/Desktop"
-        elsif ENV.has_key?("USERPROFILE") and Dir.exists?(ENV["USERPROFILE"] + "/Desktop")
+        elsif ENV.has_key?("USERPROFILE") and Dir.exist?(ENV["USERPROFILE"] + "/Desktop")
           dialog.current_folder = ENV["USERPROFILE"] + "/Desktop"
         end
       end


### PR DESCRIPTION
Replace `exists?` with `exist?`.
This is because `exists?` is deprecated. 
`exists?` is deprecated because `exists` is Third-Person Singular Forms of Verbs.

![image](https://user-images.githubusercontent.com/5798442/110240768-c611b700-7f90-11eb-99f9-2316b663d4d7.png)
