### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.gem
+*.lock
+/.bundle/
+/coverage/
+/doc/
+/pkg/
+


### PR DESCRIPTION
This pull request is just a suggestion.

1. Prevents git from tracking the directory of documents generated by `yard` or `rdoc`.
2. Prevents git from tracking the `Gemfile.lock`.
3. Prevents git from tracking gem files generated by gem build.

You may not actually use coverage directory. Because there is no test. I use yard and bundler. So it would be helpful if there is a gitignore in the directory.
