### PR TITLE
Add rexml to runtime dependencies

### DIFF
--- a/rbpad.gemspec
+++ b/rbpad.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "rexml", "~> 3.2"
   spec.add_runtime_dependency "gtksourceview3", "~> 3.3", ">= 3.3.1"
 
   #spec.add_development_dependency "bundler", "~> 1.17"


### PR DESCRIPTION
rexml is bundled gem in Ruby 3.0

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
>The following default gems are now bundled gems.
>    * rexml
>    * rss

You will probably need to specify rexml explicitly.