### PR TITLE
Allow rbpad to be called as a library

### DIFF
--- a/exe/rbpad
+++ b/exe/rbpad
@@ -1,3 +1,21 @@
 #!/usr/bin/env ruby
 
 require "rbpad"
+
+opts = ARGV.getopts('ex')
+
+lang = (opts['e'] ? :en : :jp)           # :jp or :en
+
+if opts['x']
+  pad = Rbpad::Pad.new(lang, 0, 0)       # maximized
+else
+  if ARGV.size >= 2
+    w = ARGV[0].to_i
+    h = ARGV[1].to_i
+    pad = Rbpad::Pad.new(lang, w, h)     # specified
+  else
+    pad = Rbpad::Pad.new(lang)           # default
+  end
+end
+
+Gtk.main

--- a/lib/rbpad.rb
+++ b/lib/rbpad.rb
@@ -11,22 +11,3 @@ require 'optparse'
 require 'rbpad/pad'
 
 Encoding.default_external = 'UTF-8'
-
-opts = ARGV.getopts('ex')
-
-lang = (opts['e'] ? :en : :jp)           # :jp or :en
-
-if opts['x']
-  pad = Rbpad::Pad.new(lang, 0, 0)       # maximized
-else
-  if ARGV.size >= 2
-    w = ARGV[0].to_i
-    h = ARGV[1].to_i
-    pad = Rbpad::Pad.new(lang, w, h)     # specified
-  else
-    pad = Rbpad::Pad.new(lang)           # default
-  end
-end
-
-Gtk.main
-


### PR DESCRIPTION
Hello. 
The purpose of this pull request is to be able to call rbpad as a library. 

I think `require "rbpad"` or `bundle exec irb -r rbpad` should not trigger the mainloop: `GTK.main`.

This is useful for adding tests in the future.

See the Rake case.

* https://github.com/ruby/rake/blob/master/lib/rake.rb
* https://github.com/ruby/rake/blob/master/exe/rake
  * https://github.com/ruby/rake/blob/fc688bd8cd6b4178178a0d7bb31068122ba25943/lib/rake/application.rb#L79-L85

One idea is to add `run` method or something to Pad class and move the process there.